### PR TITLE
types全体にコメントを追加

### DIFF
--- a/app/graphql/resolvers/categories_resolver.rb
+++ b/app/graphql/resolvers/categories_resolver.rb
@@ -1,6 +1,6 @@
 module Resolvers
   class CategoriesResolver < Resolvers::BaseResolver
-    description 'カテゴリー一覧を取得する'
+    description 'カテゴリー一覧'
     type [Types::CategoryType], null: false
 
     def resolve

--- a/app/graphql/resolvers/member_resolver.rb
+++ b/app/graphql/resolvers/member_resolver.rb
@@ -1,6 +1,6 @@
 module Resolvers
   class MemberResolver < Resolvers::BaseResolver
-    description 'メンバーをIDで検索する'
+    description 'メンバー'
 
     type Types::MemberType, null: false
 

--- a/app/graphql/resolvers/members_resolver.rb
+++ b/app/graphql/resolvers/members_resolver.rb
@@ -1,6 +1,6 @@
 module Resolvers
   class MembersResolver < Resolvers::BaseResolver
-    description 'メンバー一覧を取得する'
+    description 'メンバー一覧'
     type Types::MemberType.connection_type, null: false
 
     def resolve

--- a/app/graphql/resolvers/prefectures_resolver.rb
+++ b/app/graphql/resolvers/prefectures_resolver.rb
@@ -1,6 +1,6 @@
 module Resolvers
   class PrefecturesResolver < Resolvers::BaseResolver
-    description '都道府県一覧を取得する'
+    description '都道府県一覧'
     type [Types::PrefectureType], null: false
 
     def resolve

--- a/app/graphql/types/category_type.rb
+++ b/app/graphql/types/category_type.rb
@@ -1,8 +1,10 @@
 module Types
   class CategoryType < Types::BaseObject
-    field :id, ID, null: false
-    field :name, String, null: false
-    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
-    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    description 'カテゴリー'
+
+    field :id, ID, 'ID', null: false
+    field :name, String, 'カテゴリー名', null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, '作成日時', null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, '更新日時', null: false
   end
 end

--- a/app/graphql/types/hobby_type.rb
+++ b/app/graphql/types/hobby_type.rb
@@ -1,11 +1,13 @@
 module Types
   class HobbyType < Types::BaseObject
-    field :id, ID, null: false
-    field :name, String, null: false
-    field :category_id, Integer, null: true
-    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
-    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    description '趣味'
 
-    field :category, Types::CategoryType, null: false
+    field :id, ID, 'ID', null: false
+    field :name, String, '趣味名', null: false
+    field :category_id, Integer, 'カテゴリーID', null: true
+    field :created_at, GraphQL::Types::ISO8601DateTime, '作成日時', null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, '更新日時', null: false
+
+    field :category, Types::CategoryType, 'カテゴリー情報', null: false
   end
 end

--- a/app/graphql/types/member_type.rb
+++ b/app/graphql/types/member_type.rb
@@ -2,22 +2,22 @@ module Types
   class MemberType < Types::BaseObject
     description 'メンバー情報'
 
-    field :id, ID, null: false
-    field :first_name, String, null: false
-    field :first_name_hiragana, String, null: false
-    field :last_name, String, null: false
-    field :last_name_hiragana, String, null: false
-    field :handle_name, String, null: false
-    field :home_prefecture_id, Integer, null: false
-    field :residence_prefecture_id, Integer,  null: false
-    field :birthday, GraphQL::Types::ISO8601DateTime, null: false
-    field :comment, String, null: false
-    field :created_at, GraphQL::Types::ISO8601DateTime,  null: false
-    field :updated_at, GraphQL::Types::ISO8601DateTime,  null: false
+    field :id, ID, 'ID', null: false
+    field :first_name, String, '名', null: false
+    field :first_name_hiragana, String, '名(ふりがな)', null: false
+    field :last_name, String, '姓', null: false
+    field :last_name_hiragana, String, '姓(ふりがな)', null: false
+    field :handle_name, String, 'ハンドルネーム', null: false
+    field :home_prefecture_id, Integer, '出身都道府県ID', null: false
+    field :residence_prefecture_id, Integer, '現住都道府県ID', null: false
+    field :birthday, GraphQL::Types::ISO8601DateTime, '誕生日', null: false
+    field :comment, String, 'コメント', null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, '作成日時', null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, '更新日時', null: false
 
-    field :home_prefecture, Types::PrefectureType, null: false
-    field :residence_prefecture, Types::PrefectureType, null: false
-    field :hobbies, [Types::HobbyType], null: false
-    field :specialities, [Types::SpecialityType], null: false
+    field :home_prefecture, Types::PrefectureType, '出身都道府県', null: false
+    field :residence_prefecture, Types::PrefectureType, '現住都道府県', null: false
+    field :hobbies, [Types::HobbyType], '趣味一覧', null: false
+    field :specialities, [Types::SpecialityType], '特技一覧', null: false
   end
 end

--- a/app/graphql/types/prefecture_type.rb
+++ b/app/graphql/types/prefecture_type.rb
@@ -2,9 +2,9 @@ module Types
   class PrefectureType < Types::BaseObject
     description '都道府県'
 
-    field :id, ID, null: false
-    field :name, String, null: false
-    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
-    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :id, ID, 'ID', null: false
+    field :name, String, '都道府県名', null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, '作成日時', null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, '更新日時', null: false
   end
 end

--- a/app/graphql/types/speciality_type.rb
+++ b/app/graphql/types/speciality_type.rb
@@ -1,11 +1,13 @@
 module Types
   class SpecialityType < Types::BaseObject
-    field :id, ID, null: false
-    field :name, String, null: false
-    field :category_id, Integer, null: false
-    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
-    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    description '特技'
 
-    field :category, Types::CategoryType, null: false
+    field :id, ID, 'ID', null: false
+    field :name, String, '特技名', null: false
+    field :category_id, Integer, 'カテゴリーID', null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, '作成日時', null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, '更新日時', null: false
+
+    field :category, Types::CategoryType, 'カテゴリー情報', null: false
   end
 end


### PR DESCRIPTION
## 目的
- types全体にコメントを追加するため

## 備考
- コメントの記載が全体的に漏れていた。
- resolverは取得するリソース名とした。
