### PR TITLE
コミットから漏れたコメントを追加

### DIFF
--- a/app/graphql/mutations/create_category.rb
+++ b/app/graphql/mutations/create_category.rb
@@ -2,9 +2,9 @@ module Mutations
   class CreateCategory < BaseMutation
     description 'カテゴリーを作成する'
 
-    field :category, Types::CategoryType, null: false
+    field :category, Types::CategoryType, 'カテゴリー', null: false
 
-    argument :name, String, required: true
+    argument :name, String, 'カテゴリー名', required: true
 
     def resolve(**params)
       category = Category.create!(params)


### PR DESCRIPTION
## 目的
- カテゴリー作成のmutationにコメントを追加するため

## 備考
- コミットから漏れた
