### PR TITLE
仮ユーザーの登録機能を作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore .env files
+.env*

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'puma', '~> 4.1'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'bcrypt', '~> 3.1.7'
 gem 'bootsnap', '>= 1.4.2', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -42,3 +42,5 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'graphql'
+
+gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,10 @@ GEM
     byebug (11.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     ffi (1.15.4)
     globalid (0.5.2)
@@ -97,6 +101,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.4.1)
@@ -172,10 +178,12 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
   byebug
+  dotenv-rails
   graphql
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)
+  rack-cors
   rails (~> 6.0.3, >= 6.0.3.7)
   rubocop
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
     ast (2.4.2)
+    bcrypt (3.1.16)
     bootsnap (1.9.1)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -168,6 +169,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
   byebug
   graphql

--- a/app/graphql/mutations/create_temporary_user.rb
+++ b/app/graphql/mutations/create_temporary_user.rb
@@ -1,0 +1,21 @@
+module Mutations
+  class CreateTemporaryUser < BaseMutation
+    description '仮ユーザー登録を行う'
+
+    field :temporary_user, Types::TemporaryUserType, '仮ユーザー情報', null: false
+
+    argument :email, String, 'メールアドレス', required: true
+    argument :password, String, 'パスワード', required: true
+    argument :password_confirmation, String, '再確認用パスワード', required: true
+
+    def resolve(**params)
+      params[:uuid] = SecureRandom.uuid
+      begin
+        temporary_user = TemporaryUser.create!(params)
+        { temporary_user: temporary_user }
+      rescue ActiveRecord::RecordInvalid => e
+        GraphQL::ExecutionError.new(e, extensions: { code: 'RECORD_INVALID' })
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/create_user.rb
+++ b/app/graphql/mutations/create_user.rb
@@ -1,0 +1,20 @@
+module Mutations
+  class CreateUser < BaseMutation
+    description 'ユーザー登録を完了する'
+
+    field :user, Types::UserType, 'ユーザー情報', null: false
+
+    argument :uuid, String, 'UUID', required: true
+
+    def resolve(uuid:)
+      temporary_user = TemporaryUser.find_by(uuid: uuid)
+      unless temporary_user
+        GraphQL::ExecutionError.new('内部的なエラーのため登録できませんでした。', extensions: { code: 'INTERNAL_SERVER_ERROR' })
+      end
+      user = User.new(email: temporary_user.email, password_digest: temporary_user.password_digest, role: 0)
+      user.save!
+      temporary_user.destroy
+      { user: user }
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,5 +1,6 @@
 module Types
   class MutationType < Types::BaseObject
+    field :create_temporary_user, mutation: Mutations::CreateTemporaryUser
     field :create_speciality, mutation: Mutations::CreateSpeciality
     field :create_hobby, mutation: Mutations::CreateHobby
     field :create_member, mutation: Mutations::CreateMember

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,5 +1,6 @@
 module Types
   class MutationType < Types::BaseObject
+    field :create_user, mutation: Mutations::CreateUser
     field :create_temporary_user, mutation: Mutations::CreateTemporaryUser
     field :create_speciality, mutation: Mutations::CreateSpeciality
     field :create_hobby, mutation: Mutations::CreateHobby

--- a/app/graphql/types/temporary_user_type.rb
+++ b/app/graphql/types/temporary_user_type.rb
@@ -1,0 +1,11 @@
+module Types
+  class TemporaryUserType < Types::BaseObject
+    description '仮ユーザー'
+
+    field :id, ID, 'ID', null: false
+    field :email, String, 'メールアドレス', null: false
+    field :uuid, String, 'UUID', null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -1,0 +1,9 @@
+module Types
+  class UserType < Types::BaseObject
+    field :id, ID, null: false
+    field :email, String, null: false
+    field :role, Integer, null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/app/models/temporary_user.rb
+++ b/app/models/temporary_user.rb
@@ -1,7 +1,15 @@
 class TemporaryUser < ApplicationRecord
+  VALID_EMAIL_REGEX = /[\w\-._]+@[\w\-._]+\.[A-Za-z]+/
+  VALID_PASSWORD_REGEX = /((?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])|(?=.*[a-z])(?=.*[A-Z])(?=.*[!@_#¥=?;:])|(?=.*[A-Z])(?=.*[0-9])(?=.*[!@_#¥=?;:])|(?=.*[a-z])(?=.*[0-9])(?=.*[!@_#¥=?;:]))/
+
   has_secure_password
-  validates :email, uniqueness: true, format: { with: /[\w\-._]+@[\w\-._]+\.[A-Za-z]+/ }
-  validates :password, presence: true, length: { minimum: 8 },
-                       format: { with: /((?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])|(?=.*[a-z])(?=.*[A-Z])(?=.*[!@_#¥=?;:])|(?=.*[A-Z])(?=.*[0-9])(?=.*[!@_#¥=?;:])|(?=.*[a-z])(?=.*[0-9])(?=.*[!@_#¥=?;:]))/ }
-  validates :uuid, uniqueness: true
+  validates :email,
+            uniqueness: true,
+            format: { with: VALID_EMAIL_REGEX }
+  validates :password,
+            presence: true,
+            length: { minimum: 8 },
+            format: { with: VALID_PASSWORD_REGEX }
+  validates :uuid,
+            uniqueness: true
 end

--- a/app/models/temporary_user.rb
+++ b/app/models/temporary_user.rb
@@ -1,0 +1,4 @@
+class TemporaryUser < ApplicationRecord
+  validates :email, uniqueness: true
+  validates :uuid, uniqueness: true
+end

--- a/app/models/temporary_user.rb
+++ b/app/models/temporary_user.rb
@@ -1,4 +1,7 @@
 class TemporaryUser < ApplicationRecord
-  validates :email, uniqueness: true
+  has_secure_password
+  validates :email, uniqueness: true, format: { with: /[\w\-._]+@[\w\-._]+\.[A-Za-z]+/ }
+  validates :password, presence: true, length: { minimum: 8 },
+                       format: { with: /((?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])|(?=.*[a-z])(?=.*[A-Z])(?=.*[!@_#¥=?;:])|(?=.*[A-Z])(?=.*[0-9])(?=.*[!@_#¥=?;:])|(?=.*[a-z])(?=.*[0-9])(?=.*[!@_#¥=?;:]))/ }
   validates :uuid, uniqueness: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,13 @@
+class User < ApplicationRecord
+  VALID_EMAIL_REGEX = /[\w\-._]+@[\w\-._]+\.[A-Za-z]+/
+  VALID_PASSWORD_REGEX = /((?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])|(?=.*[a-z])(?=.*[A-Z])(?=.*[!@_#¥=?;:])|(?=.*[A-Z])(?=.*[0-9])(?=.*[!@_#¥=?;:])|(?=.*[a-z])(?=.*[0-9])(?=.*[!@_#¥=?;:]))/
+
+  has_secure_password
+  validates :email,
+            uniqueness: true,
+            format: { with: VALID_EMAIL_REGEX }
+  validates :password,
+            presence: true,
+            length: { minimum: 8 },
+            format: { with: VALID_PASSWORD_REGEX }
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins ENV['FRONT_APP_URL']
+
+    resource '*',
+             headers: :any,
+             methods: %i[get post put patch delete options head]
+  end
+end

--- a/db/migrate/20211205083009_create_temporary_users.rb
+++ b/db/migrate/20211205083009_create_temporary_users.rb
@@ -2,7 +2,7 @@ class CreateTemporaryUsers < ActiveRecord::Migration[6.0]
   def change
     create_table :temporary_users do |t|
       t.string :email, null: false, index: { unique: true }
-      t.string :password, null: false
+      t.string :password_digest, null: false
       t.string :uuid, null: false, index: { unique: true }
 
       t.timestamps

--- a/db/migrate/20211205083009_create_temporary_users.rb
+++ b/db/migrate/20211205083009_create_temporary_users.rb
@@ -1,0 +1,11 @@
+class CreateTemporaryUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :temporary_users do |t|
+      t.string :email, null: false, index: { unique: true }
+      t.string :password, null: false
+      t.string :uuid, null: false, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211207143828_create_users.rb
+++ b/db/migrate/20211207143828_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+      t.string :email, null: false, index: { unique: true }
+      t.string :password_digest, null: false
+      t.integer :role, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_16_133837) do
+ActiveRecord::Schema.define(version: 2021_12_05_083009) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,16 @@ ActiveRecord::Schema.define(version: 2021_11_16_133837) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["category_id"], name: "index_specialities_on_category_id"
+  end
+
+  create_table "temporary_users", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "password", null: false
+    t.string "uuid", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_temporary_users_on_email", unique: true
+    t.index ["uuid"], name: "index_temporary_users_on_uuid", unique: true
   end
 
   add_foreign_key "hobbies", "categories"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -80,7 +80,7 @@ ActiveRecord::Schema.define(version: 2021_12_05_083009) do
 
   create_table "temporary_users", force: :cascade do |t|
     t.string "email", null: false
-    t.string "password", null: false
+    t.string "password_digest", null: false
     t.string "uuid", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_05_083009) do
+ActiveRecord::Schema.define(version: 2021_12_07_143828) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,6 +86,15 @@ ActiveRecord::Schema.define(version: 2021_12_05_083009) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_temporary_users_on_email", unique: true
     t.index ["uuid"], name: "index_temporary_users_on_uuid", unique: true
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "password_digest", null: false
+    t.integer "role", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
   add_foreign_key "hobbies", "categories"


### PR DESCRIPTION
## 目的
- ユーザー登録機能を作成するため

## TODO
- [x] TemporaryUserモデルの作成
- [x] パスワードが一致しない場合のエラーハンドリング
- [x] パスワードのハッシュ化
- [x] CORSを設定
- [x] メールアドレス確認後のTemporaryUserテーブルからUsersテーブルへのデータ移行

## 備考
- `rails g graphql:object TemporaryUser`でtypeを生成できる
- メールアドレスの正規表現参考
https://qiita.com/str32/items/a692073af32757618042
- パスワードの正規表現参考
https://it-blue-collar-dairy.com/password_regex/
- 値の検証はmodelで行うものとした
- パスワードのハッシュ化周り参考
https://railstutorial.jp/chapters/modeling_users?version=5.1#sec-a_hashed_password
- メール送信処理は別途実装することにした