### PR TITLE
ユーザー登録時のメール認証処理を追加

### DIFF
--- a/app/graphql/mutations/create_temporary_user.rb
+++ b/app/graphql/mutations/create_temporary_user.rb
@@ -12,6 +12,7 @@ module Mutations
       params[:uuid] = SecureRandom.uuid
       begin
         temporary_user = TemporaryUser.create!(params)
+        UserRegistrationMailer.send_confirmation(temporary_user).deliver
         { temporary_user: temporary_user }
       rescue ActiveRecord::RecordInvalid => e
         GraphQL::ExecutionError.new(e, extensions: { code: 'RECORD_INVALID' })

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: "Profile Book <#{ENV['EMAIL_ADDRESS']}>"
   layout 'mailer'
 end

--- a/app/mailers/user_registration_mailer.rb
+++ b/app/mailers/user_registration_mailer.rb
@@ -1,0 +1,7 @@
+class UserRegistrationMailer < ApplicationMailer
+  def send_confirmation(temporary_user)
+    @link = "#{ENV['FRONT_APP_URL']}/user-registration/complete?uuid=#{temporary_user.uuid}"
+    @email = temporary_user.email
+    mail to: temporary_user.email, subject: '[Profile Book] ユーザー登録の確認'
+  end
+end

--- a/app/views/user_registration_mailer/send_confirmation.html.erb
+++ b/app/views/user_registration_mailer/send_confirmation.html.erb
@@ -1,0 +1,51 @@
+
+<head>
+	<title></title>
+	<style>
+		.title {
+			color: #0d47a1;
+		}
+
+		.link {
+			display: block;
+			width: fit-content;
+			background-color: #0d47a1;
+			margin: 0 auto 20px;
+			padding: 10px 20px;
+			border-radius: 5px;
+			color: #fff !important;
+			text-decoration: none;
+			font-weight: 700;
+			text-align: center;
+		}
+
+		.link:hover {
+			opacity: 0.8;
+			transition: opacity 0.5s;
+		}
+	</style>
+</head>
+<body>
+	<h2 class="title">Profile Bookへの登録を完了してください</h2>
+	<p>
+		<%= @email %> 様
+	</p>
+	<p>
+		ユーザー登録の完了にあたり本メールの下記リンクにアクセスいただき、認証を行うことで本サービスがご利用いただけるようになります。
+	</p>
+
+	<a 
+		href="<%= @link %>"
+		target="_blank"
+		rel="noopener noreferrer"
+		class="link"
+	>
+		登録を完了する
+	</a>
+
+	<p>
+		お手数ですがご確認よろしくお願いいたします。<br>
+		&#40;上記リンクの有効期限は配信から24時間以内となります。
+		有効期限を過ぎてしまった場合はお手数ですが再度ユーザー登録をお願いいたします。&#41;
+	</p>
+</body>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,9 +29,18 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    port:                 587,
+    address:              'smtp.gmail.com',
+    domain:               'gmail.com',
+    user_name:            ENV['EMAIL_ADDRESS'],
+    password:             ENV['EMAIL_APP_PASSWORD'],
+    authentication:       'login',
+    enable_starttls_auto: true
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log


### PR DESCRIPTION
## 目的
- ユーザー登録時にメール認証を行うため

## 備考
- 環境変数に下記を追加
  - EMAIL_ADDRESS
  - EMAIL_APP_PASSWORD
- 参考
https://qiita.com/annaaida/items/81d8a3f1b7ae3b52dc2b