### PR TITLE
ユーザー登録時のメールアドレス認証メールの文面を日本語に変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,3 +46,5 @@ gem 'graphql'
 gem 'dotenv-rails'
 
 gem 'graphql_devise'
+gem 'devise-i18n'
+gem 'devise-i18n-views'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,9 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.10.1)
+      devise (>= 4.8.0)
+    devise-i18n-views (0.3.7)
     devise_token_auth (1.2.0)
       bcrypt (~> 3.0)
       devise (> 3.5.2, < 5)
@@ -198,6 +201,8 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
   byebug
+  devise-i18n
+  devise-i18n-views
   dotenv-rails
   graphql
   graphql_devise

--- a/app/views/graphql_devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/graphql_devise/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,14 @@
+<h2>Profile Bookへの登録を完了してください</h2>
+<p><%= @email %> 様</p>
+
+<p><%= t('.confirm_link_msg') %></p>
+
+<p>
+  <%= link_to t('.confirm_account_link'), "#{message['redirect-url'].to_s}?#{{ confirmationToken: @token }.to_query}" %>
+</p>
+
+<p>
+	お手数ですがご確認よろしくお願いいたします。<br>
+	&#40;上記リンクの有効期限は配信から24時間以内となります。
+	有効期限を過ぎてしまった場合はお手数ですが再度ユーザー登録をお願いいたします。&#41;
+</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,17 +1,17 @@
 require_relative 'boot'
 
-require "rails"
+require 'rails'
 # Pick the frameworks you want:
-require "active_model/railtie"
-require "active_job/railtie"
-require "active_record/railtie"
-require "active_storage/engine"
-require "action_controller/railtie"
-require "action_mailer/railtie"
-require "action_mailbox/engine"
-require "action_text/engine"
-require "action_view/railtie"
-require "action_cable/engine"
+require 'active_model/railtie'
+require 'active_job/railtie'
+require 'active_record/railtie'
+require 'active_storage/engine'
+require 'action_controller/railtie'
+require 'action_mailer/railtie'
+require 'action_mailbox/engine'
+require 'action_text/engine'
+require 'action_view/railtie'
+require 'action_cable/engine'
 # require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
@@ -33,5 +33,7 @@ module ProfileBookApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -30,7 +30,7 @@ Devise.setup do |config|
   config.mailer = 'Devise::Mailer'
 
   # Configure the parent class responsible to send e-mails.
-  # config.parent_mailer = 'ActionMailer::Base'
+  config.parent_mailer = 'ApplicationMailer'
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -56,6 +56,6 @@ DeviseTokenAuth.setup do |config|
   # By default DeviseTokenAuth will not send confirmation email, even when including
   # devise confirmable module. If you want to use devise confirmable module and
   # send email, set it to true. (This is a setting for compatibility)
-  config.default_confirm_success_url = 'https://www.google.com'
-  config.redirect_whitelist = ['https://www.google.com']
+  config.default_confirm_success_url = ENV['FRONT_APP_URL']
+  config.redirect_whitelist = [ENV['FRONT_APP_URL']]
 end

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,65 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+ja:
+  graphql_devise:
+    mailer:
+      confirmation_instructions:
+        confirm_link_msg: 'ユーザー登録の完了にあたり下記リンクにアクセスいただき、認証を行うことで本サービスがご利用いただけるようになります。'
+        confirm_account_link: '登録を完了する'
+  devise:
+    confirmations:
+      confirmed: 'アカウントを登録しました。'
+      send_instructions: 'アカウントの有効化について数分以内にメールでご連絡します。'
+      send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。"
+    failure:
+      already_authenticated: 'すでにログインしています。'
+      inactive: 'アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。'
+      invalid: "%{authentication_keys} もしくはパスワードが不正です。"
+      locked: 'あなたのアカウントは凍結されています。'
+      last_attempt: 'あなたのアカウントが凍結される前に、複数回の操作がおこなわれています。'
+      not_found_in_database: "%{authentication_keys} もしくはパスワードが不正です。"
+      timeout: 'セッションがタイムアウトしました。もう一度ログインしてください。'
+      unauthenticated: 'アカウント登録もしくはログインしてください。'
+      unconfirmed: 'メールアドレスの本人確認が必要です。'
+    mailer:
+      confirmation_instructions:
+        subject: '[Profile Book] ユーザー登録の確認'
+      reset_password_instructions:
+        subject: 'パスワードの再設定について'
+      unlock_instructions:
+        subject: 'アカウントの凍結解除について'
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      no_token: "このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。"
+      send_instructions: 'パスワードの再設定について数分以内にメールでご連絡いたします。'
+      send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。"
+      updated: 'パスワードが正しく変更されました。'
+      updated_not_active: 'パスワードが正しく変更されました。'
+    registrations:
+      destroyed: 'アカウントを削除しました。またのご利用をお待ちしております。'
+      signed_up: 'アカウント登録が完了しました。'
+      signed_up_but_inactive: 'ログインするためには、アカウントを有効化してください。'
+      signed_up_but_locked: 'アカウントが凍結されているためログインできません。'
+      signed_up_but_unconfirmed: '本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。'
+      update_needs_confirmation: 'アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。'
+      updated: 'アカウント情報を変更しました。'
+    sessions:
+      signed_in: 'ログインしました。'
+      signed_out: 'ログアウトしました。'
+      already_signed_out: '既にログアウト済みです。'
+    unlocks:
+      send_instructions: 'アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+      send_paranoid_instructions: 'アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+      unlocked: 'アカウントを凍結解除しました。'
+  errors:
+    messages:
+      already_confirmed: 'は既に登録済みです。ログインしてください。'
+      confirmation_period_expired: "の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。"
+      expired: 'の有効期限が切れました。新しくリクエストしてください。'
+      not_found: 'は見つかりませんでした。'
+      not_locked: 'は凍結されていません。'
+      not_saved:
+        one: "エラーが発生したため %{resource} は保存されませんでした:"
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした:"


### PR DESCRIPTION
## 目的
- ユーザー登録時のメールアドレス認証メールの文面を日本語に変更するため

## 備考
- i18nのプラグインを使用したが英語対応する必要はないため日本語ファイルを入れる必要はなかったかもしれない（経験ということで）
- 参考：
https://github.com/graphql-devise/graphql_devise#customizing-email-templates
