### PR TITLE
deviseで発行されたトークンを使用して本会員登録を行う

### DIFF
--- a/app/graphql/mutations/confirm_registration_with_token.rb
+++ b/app/graphql/mutations/confirm_registration_with_token.rb
@@ -1,0 +1,4 @@
+module Mutations
+  class ConfirmRegistrationWithToken < GraphqlDevise::Mutations::ConfirmRegistrationWithToken
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,6 +1,7 @@
 module Types
   class MutationType < Types::BaseObject
     field :sign_up, mutation: Mutations::SignUp
+    field :confirm_registration_with_token, mutation: Mutations::ConfirmRegistrationWithToken
     field :create_temporary_user, mutation: Mutations::CreateTemporaryUser
     field :create_speciality, mutation: Mutations::CreateSpeciality
     field :create_hobby, mutation: Mutations::CreateHobby

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,8 @@ Rails.application.routes.draw do
     at: '/graphql_auth',
     operations: {
       # login: Mutations::Login,
-      register: Mutations::SignUp
+      register: Mutations::SignUp,
+      confirm_registration_with_token: Mutations::ConfirmRegistrationWithToken
     }
   )
   post '/graphql', to: 'graphql#execute'


### PR DESCRIPTION
## 目的
- ユーザー登録時のメールアドレスの有効性確認のため

## 備考
- GraphqlDevise::Mutations::ConfirmRegistrationWithToken（下記リンク）をそのまま使ってもよかったが今後の拡張などを考慮してresolverは中身を空にして作成した。
https://github.com/graphql-devise/graphql_devise/blob/master/lib/graphql_devise/mutations/confirm_registration_with_token.rb